### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Geodesi
+version: 3.0
+organization: Geodesi
+product: Romvær
+repo_types: [Documentation]
+platforms: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "BiScEF"
+  tags:
+  - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "n_yaktig_og_p_litelig_posisjon_til_alle_(nppa)"
+  system: "romvaer"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_BiScEF"
+  title: "Security Champion BiScEF"
+spec:
+  type: "security_champion"
+  parent: "geodesi_security_champions"
+  members:
+  - "knutstanley"
+  children:
+  - "resource:BiScEF"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "BiScEF"
+  links:
+  - url: "https://github.com/kartverket/BiScEF"
+    title: "BiScEF på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_BiScEF"
+  dependencyOf:
+  - "component:BiScEF"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Geodesi`
- `product: Romvær`
- `repo_types: [Documentation]`
- `platforms: []`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.