### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @knutstanley
+/.security/ @knutstanley

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Geodesi
 product: Romvær
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "n_yaktig_og_p_litelig_posisjon_til_alle_(nppa)"
   system: "romvaer"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_BiScEF"
-  title: "Security Champion BiScEF"
-spec:
-  type: "security_champion"
-  parent: "geodesi_security_champions"
-  members:
-  - "knutstanley"
-  children:
-  - "resource:BiScEF"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "BiScEF"
-  links:
-  - url: "https://github.com/kartverket/BiScEF"
-    title: "BiScEF på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_BiScEF"
-  dependencyOf:
-  - "component:BiScEF"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml